### PR TITLE
[Backend : fix] GptScheduleDto 멤버변수 형식 변환 및 S3 경로 반환

### DIFF
--- a/backend/src/main/java/com/isp/backend/domain/gpt/config/GptConfig.java
+++ b/backend/src/main/java/com/isp/backend/domain/gpt/config/GptConfig.java
@@ -15,9 +15,9 @@ public class GptConfig {
     public static final String CHAT_URL = "https://api.openai.com/v1/chat/completions";
     public static final String PROMPT = """
                         I would like you to plan a package tour program to plan your travel itinerary.Destination: %s
-                        Purpose of travel: %s
                         Departure date: %s
                         Entry date: %s
+                        Purpose of travel: %s
                         The flight schedule is as follows.
                         
                         Also, plan your itinerary based on the travel distance and famous tourist destinations.

--- a/backend/src/main/java/com/isp/backend/domain/gpt/constant/ParsingConstants.java
+++ b/backend/src/main/java/com/isp/backend/domain/gpt/constant/ParsingConstants.java
@@ -11,4 +11,5 @@ public class ParsingConstants {
     public static final List<String> FILTER_STRINGS = List.of(
             "Message(role=assistant, content=", ")"
             );
+    public static final int GROUP_MATCH = 1;
 }

--- a/backend/src/main/java/com/isp/backend/domain/gpt/constant/ParsingConstants.java
+++ b/backend/src/main/java/com/isp/backend/domain/gpt/constant/ParsingConstants.java
@@ -6,6 +6,7 @@ public class ParsingConstants {
     public static final String DATE_REGEX = "(\\d{4}-\\d{2}-\\d{2})";
     public static final String NEW_LINE_REGEX = "\n";
     public static final String CURRENT_DATE = "";
+    public static final String COMMA = ", ";
     public static final int BEGIN_INDEX = 3;
     public static final List<String> FILTER_STRINGS = List.of(
             "Message(role=assistant, content=", ")"

--- a/backend/src/main/java/com/isp/backend/domain/gpt/dto/GptScheduleRequestDto.java
+++ b/backend/src/main/java/com/isp/backend/domain/gpt/dto/GptScheduleRequestDto.java
@@ -4,12 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class GptScheduleRequestDto {
     private String destination;
-    private String purpose;
+    private List<String> purpose;
     private String departureDate;
     private String returnDate;
 }

--- a/backend/src/main/java/com/isp/backend/domain/gpt/dto/GptScheduleResponseDto.java
+++ b/backend/src/main/java/com/isp/backend/domain/gpt/dto/GptScheduleResponseDto.java
@@ -11,5 +11,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GptScheduleResponseDto {
+    private String countryImage;
     private List<GptSchedule> schedules;
 }

--- a/backend/src/main/java/com/isp/backend/domain/gpt/entity/GptScheduleParser.java
+++ b/backend/src/main/java/com/isp/backend/domain/gpt/entity/GptScheduleParser.java
@@ -19,7 +19,7 @@ public class GptScheduleParser {
 
         List<String> lines = List.of(scheduleText.split(ParsingConstants.NEW_LINE_REGEX));
         List<String> currentScheduleDetail = new ArrayList<>();
-        String currentDate = "";
+        String currentDate = ParsingConstants.CURRENT_DATE;
 
         for (String line : lines) {
             Matcher dateMatcher = datePattern.matcher(line);
@@ -28,7 +28,7 @@ public class GptScheduleParser {
                     schedules.add(new GptSchedule(currentDate, currentScheduleDetail));
                     currentScheduleDetail = new ArrayList<>();
                 }
-                currentDate = dateMatcher.group(1);
+                currentDate = dateMatcher.group(ParsingConstants.GROUP_MATCH);
             } else if (!line.trim().isEmpty() && ParsingConstants.FILTER_STRINGS.stream().noneMatch(line::contains)) {
                 currentScheduleDetail.add(line.trim().substring(ParsingConstants.BEGIN_INDEX)); // Remove leading index
             }

--- a/backend/src/main/java/com/isp/backend/domain/gpt/service/GptService.java
+++ b/backend/src/main/java/com/isp/backend/domain/gpt/service/GptService.java
@@ -1,6 +1,7 @@
 package com.isp.backend.domain.gpt.service;
 
 import com.isp.backend.domain.gpt.config.GptConfig;
+import com.isp.backend.domain.gpt.constant.ParsingConstants;
 import com.isp.backend.domain.gpt.dto.GptRequestDTO;
 import com.isp.backend.domain.gpt.dto.GptResponseDTO;
 import com.isp.backend.domain.gpt.dto.GptScheduleRequestDto;
@@ -85,9 +86,9 @@ public class GptService {
     private String makeQuestion(GptScheduleRequestDto questionRequestDTO) {
         return String.format(GptConfig.PROMPT,
                 questionRequestDTO.getDestination(),
-                questionRequestDTO.getPurpose(),
                 questionRequestDTO.getDepartureDate(),
-                questionRequestDTO.getReturnDate()
+                questionRequestDTO.getReturnDate(),
+                String.join(ParsingConstants.COMMA, questionRequestDTO.getPurpose())
         );
     }
 }

--- a/backend/src/main/java/com/isp/backend/domain/gpt/service/GptService.java
+++ b/backend/src/main/java/com/isp/backend/domain/gpt/service/GptService.java
@@ -9,6 +9,7 @@ import com.isp.backend.domain.gpt.dto.GptScheduleResponseDto;
 import com.isp.backend.domain.gpt.entity.GptMessage;
 import com.isp.backend.domain.gpt.entity.GptSchedule;
 import com.isp.backend.domain.gpt.entity.GptScheduleParser;
+import com.isp.backend.global.s3.service.S3ImageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,7 +21,7 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Slf4j
@@ -29,6 +30,7 @@ import java.util.List;
 public class GptService {
     private final RestTemplate restTemplate;
     private final GptScheduleParser gptScheduleParser;
+    private final S3ImageService s3ImageService;
 
     @Value("${api-key.chat-gpt}")
     private String apiKey;
@@ -40,7 +42,7 @@ public class GptService {
         return new HttpEntity<>(gptRequestDTO, httpHeaders);
     }
 
-    public GptScheduleResponseDto getResponse(HttpEntity<GptRequestDTO> chatGptRequestHttpEntity) {
+    public GptScheduleResponseDto getResponse(String destination, HttpEntity<GptRequestDTO> chatGptRequestHttpEntity) {
 
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         requestFactory.setConnectTimeout(60000);
@@ -51,8 +53,10 @@ public class GptService {
                 GptConfig.CHAT_URL,
                 chatGptRequestHttpEntity,
                 GptResponseDTO.class);
+        String countryImage = s3ImageService.get(destination);
         List<GptSchedule> gptSchedules = gptScheduleParser.parseScheduleText(getScheduleText(responseEntity));
-        return new GptScheduleResponseDto(gptSchedules);
+
+        return new GptScheduleResponseDto(countryImage, gptSchedules);
     }
 
     private String getScheduleText(ResponseEntity<GptResponseDTO> responseEntity) {
@@ -64,13 +68,17 @@ public class GptService {
     }
 
     public GptScheduleResponseDto askQuestion(GptScheduleRequestDto questionRequestDTO) {
-        List<GptMessage> messages = new ArrayList<>();
         String question = makeQuestion(questionRequestDTO);
-        messages.add(GptMessage.builder()
-                .role(GptConfig.ROLE)
-                .content(question)
-                .build());
+        List<GptMessage> messages = Collections.singletonList(
+                GptMessage.builder()
+                        .role(GptConfig.ROLE)
+                        .content(question)
+                        .build()
+        );
+
+
         return this.getResponse(
+                questionRequestDTO.getDestination(),
                 this.buildHttpEntity(
                         new GptRequestDTO(
                                 GptConfig.CHAT_MODEL,

--- a/backend/src/main/java/com/isp/backend/global/s3/repository/S3ImageRepository.java
+++ b/backend/src/main/java/com/isp/backend/global/s3/repository/S3ImageRepository.java
@@ -30,6 +30,12 @@ public class S3ImageRepository {
         return getUrl(result);
     }
 
+    public String find(String filename) {
+        String key = S3BucketDirectory.IMAGE.getDirectory() + filename;
+        final S3Resource result = s3template.download(bucketName, key);
+        return getUrl(result);
+    }
+
     private InputStream getInputStream(@RequestParam("file") MultipartFile file) {
         try {
             return file.getInputStream();

--- a/backend/src/main/java/com/isp/backend/global/s3/service/S3ImageService.java
+++ b/backend/src/main/java/com/isp/backend/global/s3/service/S3ImageService.java
@@ -16,4 +16,8 @@ public class S3ImageService {
     public String create(MultipartFile file) {
         return s3ImageRepository.save(file);
     }
+
+    public String get(String fileName) {
+        return s3ImageRepository.find(fileName);
+    }
 }


### PR DESCRIPTION
## :mag: 개요
- GptScheduleRequestDto의 purpose 형식을 String에서 List로 변환
- GptScheduleResponseDto의 destination을 기반으로 S3 경로를 함께 반환

## :memo: 작업사항
- S3에 업로드된 파일 이름 수정
- GptScheduleRequestDto의 purpose 형식을 String에서 List로 변환
- GptScheduleResponseDto의 destination을 기반으로 S3 경로를 함께 반환