### PR TITLE
[Backend : Feat] Gpt-4.0 Turbo API 호출 및 응답 개수 변경

### DIFF
--- a/backend/src/main/java/com/isp/backend/domain/gpt/config/GptConfig.java
+++ b/backend/src/main/java/com/isp/backend/domain/gpt/config/GptConfig.java
@@ -6,20 +6,22 @@ import org.springframework.context.annotation.Configuration;
 public class GptConfig {
     public static final String AUTHORIZATION = "Authorization";
     public static final String BEARER = "Bearer ";
-    public static final String CHAT_MODEL = "gpt-3.5-turbo-16k";
-    public static final Integer MAX_TOKEN = 3000;
+    public static final String CHAT_MODEL = "gpt-4-turbo";
+    public static final Integer MAX_TOKEN = 4095;
     public static final Boolean STREAM = false;
     public static final String ROLE = "user";
-    public static final Double TEMPERATURE = 0.6;
+    public static final Double TEMPERATURE = 1.5;
     public static final String MEDIA_TYPE = "application/json; charset=UTF-8";
     public static final String CHAT_URL = "https://api.openai.com/v1/chat/completions";
     public static final String PROMPT = """
+                        You're a great travel agency staff member.
                         I would like you to plan a package tour program to plan your travel itinerary.
                         
                         Also, plan your itinerary based on the travel distance and famous tourist destinations.
-                        If possible, please also provide the cost.
                         Also, be sure to include the name of the landmark or location.
+                        I want to visit a maximum of three attractions per day.
                         Make sure to plan for at least 10 hours of activity each day.
+                        Please write the itinerary without using any special characters, only in plain text.
                         
                         I would like the format to be as follows:
                         For example
@@ -60,5 +62,8 @@ public class GptConfig {
                         한국에 귀국하는 날짜: %s
                         
                         No need to say anything else, just plan your schedule right away.
-                        Please create the result in Korean.""";
+                        Please create the result in Korean.
+                        And only include schedule-related content in the schedule you're creating.
+                        Do not add any information I haven't provided to you.
+                        Under no circumstances should you include any activities other than traveling. Absolutely not.""";
 }

--- a/backend/src/main/java/com/isp/backend/domain/gpt/controller/GptController.java
+++ b/backend/src/main/java/com/isp/backend/domain/gpt/controller/GptController.java
@@ -1,7 +1,7 @@
 package com.isp.backend.domain.gpt.controller;
 
 import com.isp.backend.domain.gpt.dto.request.GptScheduleRequest;
-import com.isp.backend.domain.gpt.dto.response.GptScheduleResponse;
+import com.isp.backend.domain.gpt.dto.response.GptSchedulesResponse;
 import com.isp.backend.domain.gpt.service.GptService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,7 +15,7 @@ public class GptController {
     private final GptService gptService;
 
     @PostMapping("/schedules")
-    public GptScheduleResponse sendQuestion(@RequestBody GptScheduleRequest gptScheduleRequest) {
+    public GptSchedulesResponse sendQuestion(@RequestBody GptScheduleRequest gptScheduleRequest) {
         return gptService.askQuestion(gptScheduleRequest);
     }
 }

--- a/backend/src/main/java/com/isp/backend/domain/gpt/dto/response/GptSchedulesResponse.java
+++ b/backend/src/main/java/com/isp/backend/domain/gpt/dto/response/GptSchedulesResponse.java
@@ -1,6 +1,5 @@
 package com.isp.backend.domain.gpt.dto.response;
 
-import com.isp.backend.domain.gpt.entity.GptSchedule;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +9,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class GptScheduleResponse {
-    private List<GptSchedule> schedule;
+public class GptSchedulesResponse {
+    private String countryImage;
+    private List<GptScheduleResponse> schedules;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#61 GPT-4.0 Turbo API 연동

## 📋 PR 개요
- gpt 3.5 turbo api에서 gpt 4.0 turbo api로 업그레이드
- 일정을 여러 개 생성하도록 비즈니스 로직 및 응답 dto 수정

## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✏️ 변경 사항
- GptConfig 파일의 GPT MODEL 값 변경
- GptService의 단일 응답 생성 로직을 수정
- 여러 개의 응답을 반환하도록 GptSchedulesResponse 생성