### PR TITLE
[Backend] feat : 최근에 생성한 여행 일정 5개

### DIFF
--- a/backend/src/main/java/com/isp/backend/domain/flight/service/FlightOfferServiceImpl.java
+++ b/backend/src/main/java/com/isp/backend/domain/flight/service/FlightOfferServiceImpl.java
@@ -91,7 +91,7 @@ public class FlightOfferServiceImpl implements FlightOfferService {
         if (request.getTransferCount() == 0) {
             url += "&preferdirects=true";
         } else if (request.getTransferCount() == 1) {
-            url += "&preferdirects=false&stops=!direct";  
+            url += "&preferdirects=false&stops=!direct";
         } else {
             url += "&preferdirects=false&stops=!direct,!oneStop,!oneStop";
         }

--- a/backend/src/main/java/com/isp/backend/domain/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/isp/backend/domain/schedule/controller/ScheduleController.java
@@ -1,6 +1,7 @@
 package com.isp.backend.domain.schedule.controller;
 
 import com.isp.backend.domain.schedule.dto.response.FastestScheduleResponse;
+import com.isp.backend.domain.schedule.dto.response.LatestCreateResponse;
 import com.isp.backend.domain.schedule.dto.response.ScheduleListResponse;
 import com.isp.backend.domain.schedule.dto.request.ScheduleSaveRequest;
 import com.isp.backend.domain.schedule.service.ScheduleService;
@@ -77,7 +78,14 @@ public class ScheduleController {
 
 
     /** 내가 최근 생성한 5개 일정 조회 API **/
-//    public ResponseEntity<>
+    @GetMapping("/latest")
+    public ResponseEntity<List<LatestCreateResponse>> getLatestCreatedSchedules(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(value = "limit", defaultValue = "6") int limit) {       // 출력할 세부 일정 개수 조절
+        String memberUid = userDetails.getUsername();
+        List<LatestCreateResponse> responses = scheduleService.getLatestCreatedSchedules(memberUid, limit);
+        return ResponseEntity.ok(responses);
+    }
 
 
 }

--- a/backend/src/main/java/com/isp/backend/domain/schedule/dto/request/DailySchedule.java
+++ b/backend/src/main/java/com/isp/backend/domain/schedule/dto/request/DailySchedule.java
@@ -15,6 +15,6 @@ public class DailySchedule {
 
     private String date; // 일정 날짜
 
-    private List<ScheduleDetail> schedules; // 해당 날짜의 일정 목록
+    private List<ScheduleDetailRequest> schedules; // 해당 날짜의 일정 목록
 
 }

--- a/backend/src/main/java/com/isp/backend/domain/schedule/dto/request/ScheduleDetailRequest.java
+++ b/backend/src/main/java/com/isp/backend/domain/schedule/dto/request/ScheduleDetailRequest.java
@@ -11,7 +11,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ScheduleDetail {
+public class ScheduleDetailRequest {
 
     private String todo;        // 할 일
 

--- a/backend/src/main/java/com/isp/backend/domain/schedule/dto/response/LatestCreateResponse.java
+++ b/backend/src/main/java/com/isp/backend/domain/schedule/dto/response/LatestCreateResponse.java
@@ -5,18 +5,22 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class FastestScheduleResponse {
+public class LatestCreateResponse {
 
     private Long id;
 
-    private String scheduleName; // 여행지 이름
+    private String scheduleName;
 
-    private String dday;
+    private String city; // 여행지 장소
 
-    private String imageUrl;
+    private String imageUrl; // 이미지 url
+
+    private List<String> plan ; // 여행 일정 리스트
 
 }

--- a/backend/src/main/java/com/isp/backend/domain/schedule/repository/ScheduleRepository.java
+++ b/backend/src/main/java/com/isp/backend/domain/schedule/repository/ScheduleRepository.java
@@ -12,8 +12,10 @@ import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     Optional<Schedule> findByIdAndActivatedIsTrue(Long scheduleId);
-    @Query("SELECT s FROM Schedule s WHERE s.member = :member AND s.activated = true ORDER BY s.updatedAt DESC")
+    @Query("SELECT s FROM Schedule s LEFT JOIN FETCH s.country WHERE s.member = :member AND s.activated = true ORDER BY s.updatedAt DESC")
     List<Schedule> findSchedulesByMember(@Param("member") Member member);
-    List<Schedule> findTop5ByMemberOrderByIdDesc(Member member);
+    @Query("SELECT s FROM Schedule s LEFT JOIN FETCH s.scheduleDetails WHERE s.member = :member ORDER BY s.id DESC")
+    List<Schedule> findTop5ByMemberOrderByIdDescWithDetails(@Param("member") Member member);
+
 
 }

--- a/backend/src/main/java/com/isp/backend/domain/schedule/repository/ScheduleRepository.java
+++ b/backend/src/main/java/com/isp/backend/domain/schedule/repository/ScheduleRepository.java
@@ -2,6 +2,7 @@ package com.isp.backend.domain.schedule.repository;
 
 import com.isp.backend.domain.member.entity.Member;
 import com.isp.backend.domain.schedule.entity.Schedule;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,8 +12,8 @@ import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     Optional<Schedule> findByIdAndActivatedIsTrue(Long scheduleId);
-
     @Query("SELECT s FROM Schedule s WHERE s.member = :member AND s.activated = true ORDER BY s.updatedAt DESC")
     List<Schedule> findSchedulesByMember(@Param("member") Member member);
+    List<Schedule> findTop5ByMemberOrderByIdDesc(Member member);
 
 }

--- a/backend/src/main/java/com/isp/backend/domain/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/isp/backend/domain/schedule/service/ScheduleService.java
@@ -3,11 +3,14 @@ package com.isp.backend.domain.schedule.service;
 import com.isp.backend.domain.country.entity.Country;
 import com.isp.backend.domain.member.entity.Member;
 import com.isp.backend.domain.schedule.dto.response.FastestScheduleResponse;
+import com.isp.backend.domain.schedule.dto.response.LatestCreateResponse;
 import com.isp.backend.domain.schedule.dto.response.ScheduleListResponse;
 import com.isp.backend.domain.schedule.dto.request.ScheduleSaveRequest;
 import com.isp.backend.domain.schedule.entity.Schedule;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface ScheduleService {
 
@@ -23,6 +26,8 @@ public interface ScheduleService {
 
     ScheduleSaveRequest updateSchedule(String uid, Long scheduleId, ScheduleSaveRequest updateRequestDTO);
 
+    Optional<Schedule> findClosestSchedule(List<Schedule> schedules, LocalDate today);
+
     void calculateTotalPrice(Schedule schedule);
 
     Member validateUserCheck(String uid);
@@ -30,4 +35,6 @@ public interface ScheduleService {
     Schedule validateSchedule(Long scheduleId);
 
     Country validateCountry(String countryName);
+
+    List<LatestCreateResponse> getLatestCreatedSchedules(String uid, int limit);
 }

--- a/backend/src/main/java/com/isp/backend/domain/schedule/service/ScheduleServiceImpl.java
+++ b/backend/src/main/java/com/isp/backend/domain/schedule/service/ScheduleServiceImpl.java
@@ -2,10 +2,10 @@ package com.isp.backend.domain.schedule.service;
 
 import com.isp.backend.domain.country.entity.Country;
 import com.isp.backend.domain.country.repository.CountryRepository;
-import com.isp.backend.domain.member.dto.response.MemberDetailResponse;
 import com.isp.backend.domain.member.entity.Member;
 import com.isp.backend.domain.member.repository.MemberRepository;
 import com.isp.backend.domain.schedule.dto.response.FastestScheduleResponse;
+import com.isp.backend.domain.schedule.dto.response.LatestCreateResponse;
 import com.isp.backend.domain.schedule.dto.response.ScheduleListResponse;
 import com.isp.backend.domain.schedule.dto.request.ScheduleSaveRequest;
 import com.isp.backend.domain.schedule.entity.Schedule;
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -133,6 +133,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     }
 
     /** 나의 여행 D-day 출력 **/
+    @Override
     public FastestScheduleResponse getFastestSchedule(String uid) {
         Member findMember = validateUserCheck(uid);
         List<Schedule> schedules = scheduleRepository.findSchedulesByMember(findMember);
@@ -151,7 +152,8 @@ public class ScheduleServiceImpl implements ScheduleService {
 
 
     /**  가장 가까운 일정 찾기 **/
-    private Optional<Schedule> findClosestSchedule(List<Schedule> schedules, LocalDate today) {
+    @Override
+    public Optional<Schedule> findClosestSchedule(List<Schedule> schedules, LocalDate today) {
         return schedules.stream()
                 .filter(schedule -> LocalDate.parse(schedule.getStartDate()).isAfter(today)) // 오늘 이후의 일정
                 .min(Comparator.comparing(s -> LocalDate.parse(s.getStartDate())));          // 시작일이 가장 빠른 순으로 정렬
@@ -196,6 +198,18 @@ public class ScheduleServiceImpl implements ScheduleService {
     }
 
 
+    /** 최근에 생성한 여행 일정 top 5**/
+    @Override
+    public List<LatestCreateResponse> getLatestCreatedSchedules(String uid, int limit) {
+        Member findMember = validateUserCheck(uid);
+        List<Schedule> topSchedules = scheduleRepository.findTop5ByMemberOrderByIdDesc(findMember);
 
+        List<LatestCreateResponse> responses = new ArrayList<>();
+        for (Schedule schedule : topSchedules) {
+            LatestCreateResponse response = scheduleMapper.toLatestCreateResponse(schedule, limit);
+            responses.add(response);
+        }
+        return responses;
+    }
 
 }

--- a/backend/src/main/java/com/isp/backend/domain/schedule/service/ScheduleServiceImpl.java
+++ b/backend/src/main/java/com/isp/backend/domain/schedule/service/ScheduleServiceImpl.java
@@ -23,10 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -202,7 +199,11 @@ public class ScheduleServiceImpl implements ScheduleService {
     @Override
     public List<LatestCreateResponse> getLatestCreatedSchedules(String uid, int limit) {
         Member findMember = validateUserCheck(uid);
-        List<Schedule> topSchedules = scheduleRepository.findTop5ByMemberOrderByIdDesc(findMember);
+        List<Schedule> topSchedules = scheduleRepository.findTop5ByMemberOrderByIdDescWithDetails(findMember);
+
+        if (topSchedules.isEmpty()) {
+            throw new ScheduleNotFoundException();
+        }
 
         List<LatestCreateResponse> responses = new ArrayList<>();
         for (Schedule schedule : topSchedules) {

--- a/backend/src/main/java/com/isp/backend/domain/scheduleDetail/entity/ScheduleDetail.java
+++ b/backend/src/main/java/com/isp/backend/domain/scheduleDetail/entity/ScheduleDetail.java
@@ -4,11 +4,11 @@ import com.isp.backend.domain.schedule.entity.Schedule;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Getter
 @AllArgsConstructor
 @Entity
 @Setter
 @Builder
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "schedule_detail")
 public class ScheduleDetail {

--- a/backend/src/main/java/com/isp/backend/domain/scheduleDetail/entity/ScheduleType.java
+++ b/backend/src/main/java/com/isp/backend/domain/scheduleDetail/entity/ScheduleType.java
@@ -7,10 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ScheduleType {
 
-    AIRPLANE,       // 비행기
-
-    HOTEL,          // 호텧
-
-    PLACE,          // 관광지 장소
+    AIRPLANE,
+    HOTEL,
+    PLACE,
 
 };


### PR DESCRIPTION
## #️⃣연관된 이슈
#36 
#40 

## 📋 PR 개요
최근 생성한 여행 일정 상위 5개를 조회하는 API 
- 전체 일정 목록 조회 + 최근 생성한 여행일정 상위 조회에서 N+1 이슈 FetchJoin으로 해결
- 여행일정이 1개도 없는 유저의 경우 에러 response
- Mapper 코드에서 "ScheduleDetail" dto와 엔티티의 중복 파일명이 있던 문제 해결 

## ✅ PR 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✏️ 변경 사항
- 내용을 적어주세요.